### PR TITLE
fix: subgraph

### DIFF
--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -6,7 +6,9 @@
     "'self'",
     "data:",
     "'wasm-unsafe-eval'",
-    "https://translate.googleapis.com/"
+    "https://translate.googleapis.com/",
+    "https://posthog.reservoir.tools",
+    "https://static.cloudflareinsights.com"
   ],
   "styleSrc": [
     "'self'",
@@ -57,6 +59,8 @@
     "https://raw.githubusercontent.com",
     "https://rpc.redstonechain.com",
     "https://rpc-gel.inkonchain.com",
+    "https://posthog.reservoir.tools",
+    "https://auth.privy.io",
     "https://*.reservoir.tools/tokenlist/v1",
     "https://1rpc.io/*",
     "https://graph-node.reservoir.tools"

--- a/apps/web/public/csp.json
+++ b/apps/web/public/csp.json
@@ -6,9 +6,7 @@
     "'self'",
     "data:",
     "'wasm-unsafe-eval'",
-    "https://translate.googleapis.com/",
-    "https://posthog.reservoir.tools",
-    "https://static.cloudflareinsights.com"
+    "https://translate.googleapis.com/"
   ],
   "styleSrc": [
     "'self'",
@@ -59,10 +57,9 @@
     "https://raw.githubusercontent.com",
     "https://rpc.redstonechain.com",
     "https://rpc-gel.inkonchain.com",
-    "https://posthog.reservoir.tools",
-    "https://auth.privy.io",
     "https://*.reservoir.tools/tokenlist/v1",
-    "https://1rpc.io/*"
+    "https://1rpc.io/*",
+    "https://graph-node.reservoir.tools"
   ],
   "workerSrc": [
     "'self'",

--- a/apps/web/src/graphql/thegraph/apolloLegacy.ts
+++ b/apps/web/src/graphql/thegraph/apolloLegacy.ts
@@ -6,21 +6,20 @@ import { UniverseChainId } from 'uniswap/src/types/chains'
 export type Ticks = AllV3TicksQuery['ticks']
 export type TickData = Ticks[number]
 
+const GRAPH_NODE_URL = process.env.REACT_APP_GRAPH_NODE_URL ?? `https://graph-node.reservoir.tools`
+
 const CHAIN_SUBGRAPH_URL: Record<number, string> = {
-  [UniverseChainId.AbstractTestnet]:
-    'https://graph-node.internal.reservoir.tools/subgraphs/name/absctract-testnet/v3-subgraph',
-  [UniverseChainId.Zero]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/zero/v3-subgraph',
-  [UniverseChainId.BOB]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/bob/v3-subgraph',
-  [UniverseChainId.CYBER]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/cyber/v3-subgraph',
-  [UniverseChainId.SHAPE]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/shape/v3-subgraph',
-  [UniverseChainId.INK]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/ink/v3-subgraph',
-  [UniverseChainId.REDSTONE]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/redstone/v3-subgraph',
-  [UniverseChainId.REDSTONE_GARNET]:
-    'https://graph-node.internal.reservoir.tools/subgraphs/name/redstone-garnet/v3-subgraph',
-  [UniverseChainId.AbstractMainnet]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/abstract/v3-subgraph',
-  [UniverseChainId.AnimeTestnet]:
-    'https://graph-node.internal.reservoir.tools/subgraphs/name/anime-testnet/v3-subgraph',
-  [UniverseChainId.Mode]: 'https://graph-node.internal.reservoir.tools/subgraphs/name/mode/v3-subgraph',
+  [UniverseChainId.AbstractTestnet]: `${GRAPH_NODE_URL}/subgraphs/name/absctract-testnet/v3-subgraph`,
+  [UniverseChainId.Zero]: `${GRAPH_NODE_URL}/subgraphs/name/zero/v3-subgraph`,
+  [UniverseChainId.BOB]: `${GRAPH_NODE_URL}/subgraphs/name/bob/v3-subgraph`,
+  [UniverseChainId.CYBER]: `${GRAPH_NODE_URL}/subgraphs/name/cyber/v3-subgraph`,
+  [UniverseChainId.SHAPE]: `${GRAPH_NODE_URL}/subgraphs/name/shape/v3-subgraph`,
+  [UniverseChainId.INK]: `${GRAPH_NODE_URL}/subgraphs/name/ink/v3-subgraph`,
+  [UniverseChainId.REDSTONE]: `${GRAPH_NODE_URL}/subgraphs/name/redstone/v3-subgraph`,
+  [UniverseChainId.REDSTONE_GARNET]: `${GRAPH_NODE_URL}/subgraphs/name/redstone-garnet/v3-subgraph`,
+  [UniverseChainId.AbstractMainnet]: `${GRAPH_NODE_URL}/subgraphs/name/abstract/v3-subgraph`,
+  [UniverseChainId.AnimeTestnet]: `${GRAPH_NODE_URL}/subgraphs/name/anime-testnet/v3-subgraph`,
+  [UniverseChainId.Mode]: `${GRAPH_NODE_URL}/subgraphs/name/mode/v3-subgraph`,
 }
 
 const httpLink = new HttpLink({ uri: CHAIN_SUBGRAPH_URL[UniverseChainId.Zero] })


### PR DESCRIPTION
- Fixed missing analytics due to disabled old URL;
- Added new .env in case link is changed in the future: REACT_APP_GRAPH_NODE_URL, if empty, will default to current one.